### PR TITLE
Maintenance fixes

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 8.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/CopyOptions.cs
+++ b/CopyOptions.cs
@@ -17,7 +17,7 @@ namespace bcpJson
         [Option("source-login", Default = "", Required = false, HelpText = "Specifies the login ID used to connect to source SQL Server. Leave blank for Windows Auth.")]
         public string srcLogin { get; set; }
 
-        [Option("source-password ", Default = "", Required = false, HelpText = "Specifies the password for the source login ID. Leave blank for Windows Auth.")]
+        [Option("source-password", Default = "", Required = false, HelpText = "Specifies the password for the source login ID. Leave blank for Windows Auth.")]
         public string srcPassword { get; set; }
 
         [Option("target-server", Required = false, HelpText = "Specifies the target instance of SQL Server to which to connect.")]
@@ -29,7 +29,7 @@ namespace bcpJson
         [Option("target-login", Default = "", Required = false, HelpText = "Specifies the login ID used to connect to target SQL Server. Leave blank for Windows Auth.")]
         public string TargetSQLLogin { get; set; }
 
-        [Option("target-password ", Default = "", Required = false, HelpText = "Specifies the password for the target login ID. Leave blank for Windows Auth.")]
+        [Option("target-password", Default = "", Required = false, HelpText = "Specifies the password for the target login ID. Leave blank for Windows Auth.")]
         public string TargetSQLPassword { get; set; }
 
         [Option("source-query", Required = false, HelpText = "Transact-SQL query/procedure. If the query returns multiple result sets, only the first result set is copied to the data file; subsequent result sets are ignored.")]

--- a/ExportOptions.cs
+++ b/ExportOptions.cs
@@ -17,7 +17,7 @@ namespace bcpJson
         [Option("source-login", Default = "", Required = false, HelpText = "Specifies the login ID used to connect to source SQL Server. Leave blank for Windows Auth.")]
         public string srcLogin { get; set; }
 
-        [Option("source-password ", Default = "", Required = false, HelpText = "Specifies the password for the source login ID. Leave blank for Windows Auth.")]
+        [Option("source-password", Default = "", Required = false, HelpText = "Specifies the password for the source login ID. Leave blank for Windows Auth.")]
         public string srcPassword { get; set; }
 
         [Option("source-query", Required = false, HelpText = "Transact-SQL query/procedure. If the query returns multiple result sets, only the first result set is copied to the data file; subsequent result sets are ignored.")]

--- a/ImportOptions.cs
+++ b/ImportOptions.cs
@@ -27,7 +27,7 @@ namespace bcpJson
         [Option("target-login", Default = "", Required = false, HelpText = "Specifies the login ID used to connect to target SQL Server. Leave blank for Windows Auth.")]
         public string TargetSQLLogin { get; set; }
 
-        [Option("target-password ", Default = "", Required = false, HelpText = "Specifies the password for the target login ID. Leave blank for Windows Auth.")]
+        [Option("target-password", Default = "", Required = false, HelpText = "Specifies the password for the target login ID. Leave blank for Windows Auth.")]
         public string TargetSQLPassword { get; set; }
 
         [Option("target-table", Required = false, HelpText = "Target table name.")]


### PR DESCRIPTION
## Summary
- update GitHub Actions to use .NET 8
- fix command-line option names without trailing spaces

## Testing
- `dotnet restore` *(fails: command not found)*
- `dotnet build --no-restore` *(fails: command not found)*
- `dotnet test --no-build --verbosity normal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3b04ccd08322abcc2ed4e310ba4f