### PR TITLE
Enhance option validation and docs

### DIFF
--- a/ExportOptions.cs
+++ b/ExportOptions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
+using System.IO;
 
 namespace bcpJson
 {
@@ -88,7 +89,22 @@ namespace bcpJson
                 return false;
             }
 
-            //TODO: PATH
+            if (string.IsNullOrEmpty(this.exportPath))
+            {
+                this.exportPath = Directory.GetCurrentDirectory();
+            }
+
+            if (!Directory.Exists(this.exportPath))
+            {
+                try
+                {
+                    Directory.CreateDirectory(this.exportPath);
+                }
+                catch
+                {
+                    return false;
+                }
+            }
 
             using (var srcconn = new SqlConnection(this.SourceConnectionString()))
             {

--- a/ImportOptions.cs
+++ b/ImportOptions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
+using System.IO;
 
 
 namespace bcpJson
@@ -58,7 +59,15 @@ namespace bcpJson
             //    return false;
             //}
 
-            //TODO: PATH
+            if (string.IsNullOrEmpty(this.SourcePath))
+            {
+                this.SourcePath = Directory.GetCurrentDirectory();
+            }
+
+            if (!Directory.Exists(this.SourcePath))
+            {
+                return false;
+            }
 
             using (var tgtconn = new SqlConnection(this.GetTargetConnectionString()))
             {

--- a/Program.cs
+++ b/Program.cs
@@ -35,7 +35,7 @@ namespace bcpJson
                 //var result = CollectionGenerate2(opts);
 
                 long result = -1;
-                switch (opts.FileFormat)
+                switch (opts.FileFormat.ToLowerInvariant())
                 {
                     case "bcp":
                         result = ExportToBCP(opts);
@@ -59,7 +59,7 @@ namespace bcpJson
                 sw.Start();
 
                 long result = -1;
-                switch (opts.FileFormat)
+                switch (opts.FileFormat.ToLowerInvariant())
                 {
                     case "bcp":
                         result = ImportFromBCP(opts);

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # BCPJSON
 
-After reading an article about how Facebook performs their MySQL backups at scale, I wanted to see if it was possible to replicate part of that model with Microsoft SQL Server.
-I set out to see if I could build a tool to unload data into a structured format that would allow for DIFF operations against the resulting archive file.
+After reading an article about how Facebook performs their MySQL backups at scale, I wanted to see if it was possible to replicate part of that model with Microsoft SQL Server. I set out to build a tool to unload data into a structured format that would allow for DIFF operations against the resulting archive file.
+
+## Usage
+
+The application is a console program targeting **.NET 8.0**. Build it using the `dotnet` CLI:
+
+```bash
+dotnet build
+```
+
+### Export
+
+```
+dotnet run -- export --source-server localhost --source-database MyDb \
+    --file-format json --export-path ./output
+```
+
+### Import
+
+```
+dotnet run -- import --file-format bcp --source-path ./output \
+    --source-file data.bcp --target-server localhost
+```
+
+If no path is provided, the current working directory is used.
 
 # Resources


### PR DESCRIPTION
## Summary
- add default path handling for export/import options
- interpret `--file-format` case-insensitively
- document build and usage examples

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3e648eb88322af3520e76cc5f740