### PR TITLE
Improve CLI validation and add optional logging

### DIFF
--- a/ExportOptions.cs
+++ b/ExportOptions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
+using System.IO;
 
 namespace bcpJson
 {
@@ -88,7 +89,22 @@ namespace bcpJson
                 return false;
             }
 
-            //TODO: PATH
+            if (string.IsNullOrWhiteSpace(this.exportPath))
+            {
+                return false;
+            }
+
+            try
+            {
+                if (!Directory.Exists(this.exportPath))
+                {
+                    Directory.CreateDirectory(this.exportPath);
+                }
+            }
+            catch
+            {
+                return false;
+            }
 
             using (var srcconn = new SqlConnection(this.SourceConnectionString()))
             {

--- a/ImportOptions.cs
+++ b/ImportOptions.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
+using System.IO;
 
 
 namespace bcpJson
@@ -58,7 +59,14 @@ namespace bcpJson
             //    return false;
             //}
 
-            //TODO: PATH
+            if (string.IsNullOrWhiteSpace(this.SourcePath) || !Directory.Exists(this.SourcePath))
+            {
+                return false;
+            }
+            if (string.IsNullOrWhiteSpace(this.SourceFile))
+            {
+                return false;
+            }
 
             using (var tgtconn = new SqlConnection(this.GetTargetConnectionString()))
             {

--- a/Program.cs
+++ b/Program.cs
@@ -14,9 +14,10 @@ using CommandLine;
 
 namespace bcpJson
 {
-	class Program
-	{
-		static void Main(string[] args)
+        class Program
+        {
+            private static StreamWriter logWriter = null;
+            static void Main(string[] args)
 		{
             CommandLine.Parser.Default.ParseArguments<ExportOptions,ImportOptions,CopyOptions>(args)
                 .WithParsed<ExportOptions>(opts => ExportData(opts))
@@ -28,6 +29,10 @@ namespace bcpJson
         {
             if (opts.Valid())
             {
+                if (!string.IsNullOrEmpty(opts.outputLogFile))
+                {
+                    logWriter = new StreamWriter(opts.outputLogFile, false);
+                }
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
@@ -48,6 +53,11 @@ namespace bcpJson
                 }
                 sw.Stop();
                 PostToConsole(string.Format("Total Exported: {0}\tRows in {1}", result, sw.Elapsed), InfoLevel.Success);
+                if (logWriter != null)
+                {
+                    logWriter.Dispose();
+                    logWriter = null;
+                }
             }
         }
 
@@ -55,6 +65,10 @@ namespace bcpJson
         {
             if (opts.Valid())
             {
+                if (!string.IsNullOrEmpty(opts.LogFile))
+                {
+                    logWriter = new StreamWriter(opts.LogFile, false);
+                }
                 Stopwatch sw = new Stopwatch();
                 sw.Start();
 
@@ -72,11 +86,20 @@ namespace bcpJson
                 }
                 sw.Stop();
                 PostToConsole(string.Format("Total Imported {0}\tRows in {1}", result, sw.Elapsed), InfoLevel.Success);
+                if (logWriter != null)
+                {
+                    logWriter.Dispose();
+                    logWriter = null;
+                }
             }
         }
 
         private static void CopyData(CopyOptions opts)
         {
+            if (!string.IsNullOrEmpty(opts.outputLogFile))
+            {
+                logWriter = new StreamWriter(opts.outputLogFile, false);
+            }
             Stopwatch sw = new Stopwatch();
             sw.Start();
 
@@ -85,6 +108,11 @@ namespace bcpJson
             var result = BulkCopyTables(opts);
             sw.Stop();
             PostToConsole(string.Format("Total Copied {0}\tRows in {1}", result, sw.Elapsed), InfoLevel.Success);
+            if (logWriter != null)
+            {
+                logWriter.Dispose();
+                logWriter = null;
+            }
         }
 
         private static long Generate(ExportOptions setting)
@@ -1308,6 +1336,11 @@ namespace bcpJson
             Console.ForegroundColor = consoleColor;
             Console.WriteLine(Message);
             Console.ResetColor();
+            if (logWriter != null)
+            {
+                logWriter.WriteLine(Message);
+                logWriter.Flush();
+            }
             return true;
         }
     }

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ After reading an article about how Facebook performs their MySQL backups at scal
 I set out to see if I could build a tool to unload data into a structured format that would allow for DIFF operations against the resulting archive file.
 
 # Resources
+
+## Logging
+Command options now support a `--log-file` argument to write console output to a file.
+
+## Validation
+Export and import commands verify that the specified paths exist. Export will create the target directory if needed.


### PR DESCRIPTION
## Summary
- support optional log file for export, import, and copy commands
- validate export and import paths
- document new features

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3e648eb88322af3520e76cc5f740