### PR TITLE
Fix build due to typo in parallel options

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -328,7 +328,7 @@ namespace bcpJson
 
                         Parallel.ForEach(
                             list,
-                            new ParallelOptions { MaxDegreeOfParallelism = options.MaxParallelTasks },
+                            new ParallelOptions { MaxDegreeOfParallelism = setting.MaxParallelTasks },
                             table =>
                         {
                             Thread.Sleep(10);


### PR DESCRIPTION
## Summary
- fix missing variable reference in CollectionGenerate2

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a5575aed48322bf9ccae5fd83aa36